### PR TITLE
Make font configurable

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -7,6 +7,7 @@
   course: none,
   bibliography-file: none,
   font-size: 12pt,
+  font: "Times New Roman",
   body
 ) = {
   // Set document metdata.
@@ -39,8 +40,8 @@
 
   // Set the body font.
   set text(
-    font: "Times New Roman",
-    size:   font-size,
+    font: font,
+    size: font-size,
   )
 
   // Configure headings.


### PR DESCRIPTION
This is very commonly misunderstood. The MLA spec recommends a legible, 12pt font, and gives Times New Roman as an example.  Users such as myself that find Times New Roman ugly may want to use a different font, such as Computer Modern or something similar.